### PR TITLE
Fix massive groups list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+### Added
+
+- Expansion panels for groups in Known
+- Text search includes group names
+
 ## [1.0.1-beta] - 2022-08-16
 
 ### Fixed

--- a/interface/src/components/Known.vue
+++ b/interface/src/components/Known.vue
@@ -1,11 +1,8 @@
 <template>
   <div class="tw-w-screen">
-
     <div class="tw-flex tw-space-between tw-mb-4">
       <div class="tw-grow">
-        <h3 class="tw-text-3xl tw-font-silom">
-          Known Resources
-        </h3>
+        <h3 class="tw-text-3xl tw-font-silom">Known Resources</h3>
       </div>
       <div>
         <v-btn
@@ -23,16 +20,28 @@
     </div>
 
     <div class="tw-text-right tw-mb-2">
-      <span v-if="filtersHidden" href="#" class="tw-cursor-pointer tw-text-success tw-underline" @click="filtersHidden = !filtersHidden">
+      <span
+        v-if="filtersHidden"
+        href="#"
+        class="tw-cursor-pointer tw-text-success tw-underline"
+        @click="filtersHidden = !filtersHidden"
+      >
         Show Filters
       </span>
-      <span v-else href="#" class="tw-cursor-pointer tw-text-success tw-underline" @click="filtersHidden = !filtersHidden">
+      <span
+        v-else
+        href="#"
+        class="tw-cursor-pointer tw-text-success tw-underline"
+        @click="filtersHidden = !filtersHidden"
+      >
         Hide Filters
       </span>
     </div>
 
     <div class="tw-flex tw-flex-col tw-space-between" v-if="!filtersHidden">
-      <div class="tw-flex tw-gap-y-2 tw-grid tw-grid-cols-1 md:tw-grid-cols-3 tw-gap-x-2 tw-flex-col tw-flex-wrap tw-justify-end tw-mb-2">
+      <div
+        class="tw-flex tw-gap-y-2 tw-grid tw-grid-cols-1 md:tw-grid-cols-3 tw-gap-x-2 tw-flex-col tw-flex-wrap tw-justify-end tw-mb-2"
+      >
         <div class="md:tw-basis-1/3">
           <v-select
             color="info"
@@ -72,7 +81,9 @@
         </div>
       </div>
 
-      <div class="tw-flex tw-gap-y-2 tw-flex-col md:tw-flex-row tw-flex-wrap tw-justify-end tw-mb-2">
+      <div
+        class="tw-flex tw-gap-y-2 tw-flex-col md:tw-flex-row tw-flex-wrap tw-justify-end tw-mb-2"
+      >
         <div class="md:tw-basis-2/3">
           <v-text-field
             prepend-inner-icon="mdi-magnify"
@@ -86,63 +97,152 @@
       </div>
     </div>
 
-    <div v-if="!knownPending"> <!-- loaded -->
+    <div v-if="!knownPending">
+      <!-- loaded -->
       <div>
         <ul class="tw-my-4">
-          <li v-if="filteredGroups.length === 0"
+          <p
+            v-if="filteredGroups.length === 0"
             class="tw-p-4 tw-mb-12 tw-bg-white tw-border tw-shadow-md tw-rounded-md"
           >
             No resources match these filters
-          </li>
-          <li
+          </p>
+
+          <v-expansion-panels
             v-else
+            v-model="openPanels"
             v-for="pair in filteredGroups"
             :key="pair[0]"
-            class="tw-p-4 tw-mb-12 tw-bg-white tw-border tw-shadow-md tw-rounded-md"
-          > <!-- group -->
-              <h4 class="tw-mb-4 tw-text-2xl tw-py-4">
-                <span class="font-mono">{{ pair[0] }}</span>
-              </h4>
+            multiple
+          >
+            <v-expansion-panel
+              class="tw-p-4 tw-mb-2 tw-bg-white tw-rounded-md"
+              :value="pair[0]"
+            >
+              <v-expansion-panel-title>
+                <div class="tw-w-full tw-flex tw-flex-row tw-justify-between">
+                  <div class="tw-text-xl">
+                    {{ pair[0] }}
+                  </div>
 
-              <ul class="tw-my-2">
-                <li
-                  v-for="c in filteredResources(pair[1].chats, pair[0])"
-                  :key="c.name"
-                  class="tw-p-2 tw-my-4 tw-bg-white tw-border tw-rounded-peat"
-                >
-                  <KnownResource :resource="c" shape="chat" :group="pair[0]" />
-                </li>
-              </ul>
+                  <div class="tw-flex-grow"></div>
 
-              <ul class="tw-my-2">
-                <li
-                  v-for="l in filteredResources(pair[1].links, pair[0])"
-                  :key="l.name"
-                  class="tw-p-2 tw-my-4 tw-bg-white tw-border tw-rounded-peat"
-                >
-                  <KnownResource
-                    :resource="l"
-                    shape="collection"
-                    :group="pair[0]"
-                  />
-                </li>
-              </ul>
+                  <div>
+                    <v-tooltip location="top">
+                      <template v-slot:activator="{ props }">
+                        <v-chip
+                          v-bind="props"
+                          v-if="pair[1].chats.length > 0"
+                          variant="outlined"
+                          label
+                          size="small"
+                          color="info"
+                          class="mr-2"
+                        >
+                          <v-icon start icon="mdi-chat-outline"> </v-icon>
+                          {{ pair[1].chats.length }}
+                        </v-chip>
+                      </template>
+                      <span>
+                        {{ pair[1].chats.length }} chat{{
+                          pair[1].chats.length === 1 ? `` : `s`
+                        }}
+                      </span>
+                    </v-tooltip>
 
-              <ul class="tw-my-2">
-                <li
-                  v-for="p in filteredResources(pair[1].publishes, pair[0])"
-                  :key="p.name"
-                  class="tw-p-2 tw-my-4 tw-bg-white tw-border tw-rounded-peat"
-                >
-                  <KnownResource
-                    :resource="p"
-                    shape="notebook"
-                    :group="pair[0]"
-                  />
-                </li>
-              </ul>
+                    <v-tooltip location="top">
+                      <template v-slot:activator="{ props }">
+                        <v-chip
+                          v-bind="props"
+                          v-if="pair[1].links.length > 0"
+                          variant="outlined"
+                          label
+                          size="small"
+                          color="info"
+                          class="mr-2"
+                        >
+                          <v-icon start icon="mdi-image-multiple-outline">
+                          </v-icon>
+                          {{ pair[1].links.length }}
+                        </v-chip>
+                      </template>
+                      <span>
+                        {{ pair[1].links.length }} collection{{
+                          pair[1].links.length === 1 ? `` : `s`
+                        }}
+                      </span>
+                    </v-tooltip>
 
-          </li> <!-- group -->
+                    <v-tooltip location="top">
+                      <template v-slot:activator="{ props }">
+                        <v-chip
+                          v-bind="props"
+                          v-if="pair[1].publishes.length > 0"
+                          variant="outlined"
+                          label
+                          size="small"
+                          color="info"
+                          class="mr-2"
+                        >
+                          <v-icon start icon="mdi-notebook"> </v-icon>
+                          {{ pair[1].publishes.length }}
+                        </v-chip>
+                      </template>
+                      <span>
+                        {{ pair[1].publishes.length }} notebook{{
+                          pair[1].publishes.length === 1 ? `` : `s`
+                        }}
+                      </span>
+                    </v-tooltip>
+                  </div>
+                </div>
+              </v-expansion-panel-title>
+
+              <v-expansion-panel-text>
+                <ul class="tw-my-2">
+                  <li
+                    v-for="c in filteredResources(pair[1].chats, pair[0])"
+                    :key="c.name"
+                    class="tw-p-2 tw-my-4 tw-bg-white tw-border tw-rounded-peat"
+                  >
+                    <KnownResource
+                      :resource="c"
+                      shape="chat"
+                      :group="pair[0]"
+                    />
+                  </li>
+                </ul>
+
+                <ul class="tw-my-2">
+                  <li
+                    v-for="l in filteredResources(pair[1].links, pair[0])"
+                    :key="l.name"
+                    class="tw-p-2 tw-my-4 tw-bg-white tw-border tw-rounded-peat"
+                  >
+                    <KnownResource
+                      :resource="l"
+                      shape="collection"
+                      :group="pair[0]"
+                    />
+                  </li>
+                </ul>
+
+                <ul class="tw-my-2">
+                  <li
+                    v-for="p in filteredResources(pair[1].publishes, pair[0])"
+                    :key="p.name"
+                    class="tw-p-2 tw-my-4 tw-bg-white tw-border tw-rounded-peat"
+                  >
+                    <KnownResource
+                      :resource="p"
+                      shape="notebook"
+                      :group="pair[0]"
+                    />
+                  </li>
+                </ul>
+              </v-expansion-panel-text>
+            </v-expansion-panel>
+          </v-expansion-panels>
         </ul>
       </div>
     </div>
@@ -150,7 +250,7 @@
     <div v-else>
       <ul class="tw-my-4">
         <li
-            class="tw-p-2 tw-mb-8 tw-bg-surface tw-border tw-shadow-md tw-rounded-md"
+          class="tw-p-2 tw-mb-8 tw-bg-surface tw-border tw-shadow-md tw-rounded-md"
         >
           <KnownSkeleton />
           <KnownSkeleton />
@@ -158,7 +258,7 @@
       </ul>
       <ul class="tw-my-4">
         <li
-            class="tw-p-2 tw-mb-8 tw-bg-surface tw-border tw-shadow-md tw-rounded-md"
+          class="tw-p-2 tw-mb-8 tw-bg-surface tw-border tw-shadow-md tw-rounded-md"
         >
           <KnownSkeleton />
           <KnownSkeleton />
@@ -166,7 +266,6 @@
         </li>
       </ul>
     </div>
-
   </div>
 </template>
 
@@ -182,17 +281,35 @@ import KnownSkeleton from "@/components/loading-skeletons/KnownSkeleton.vue";
 export default defineComponent({
   data() {
     return {
+      openPanels: [],
       knownPending: true,
-      adminOnly: 'all',
-      showAllExportStatus: 'all',
-      textSearch: '',
-      groupFilter: '',
+      adminOnly: "all",
+      showAllExportStatus: "all",
+      textSearch: "",
+      groupFilter: "",
       filtersHidden: false,
     };
   },
 
   mounted() {
     this.getKnown();
+  },
+
+  watch: {
+    groupFilter(val) {
+      if (val == "" || val == null || val == undefined) {
+        this.openPanels = [];
+      } else {
+        this.openPanels = [val];
+      }
+    },
+    textSearch(val) {
+      if (val == "" || val == null) {
+        this.openPanels = [];
+      } else {
+        this.openPanels = this.filteredGroups.map(g => g[0])
+      }
+    },
   },
 
   computed: {
@@ -211,25 +328,33 @@ export default defineComponent({
       return this.knownGroups;
     },
     filteredGroups() {
-      let g = []
+      let g = [];
       if (this.groupFilter) {
-        g = this.resourcesByGroup(this.groupFilter)
+        g = this.resourcesByGroup(this.groupFilter);
       } else {
-        g = this.resourcesByGroup('')
+        g = this.resourcesByGroup("");
       }
 
       g = g.filter((g) => {
         if (this.groupWillBeEmpty(g)) {
-          return false
+          return false;
         }
-        return true
-      })
+        return true;
+      });
 
-      return g
+      return g;
     },
   },
 
   methods: {
+    groupResources(group) {
+      return (
+        group[1].chats.length +
+        group[1].links.length +
+        group[1].publishes.length
+      );
+    },
+
     getKnown() {
       this.knownPending = true;
       this.$store
@@ -242,14 +367,17 @@ export default defineComponent({
         });
     },
     isAdmin(resource, groupName) {
-      return this.amAdmin(resource, groupName)
+      return this.amAdmin(resource, groupName);
     },
     isSaved(resource) {
-      return this.isRecurringSaved({ name: resource.name, ship: resource.ship })
+      return this.isRecurringSaved({
+        name: resource.name,
+        ship: resource.ship,
+      });
     },
 
     filteredResources(resources, groupName) {
-      let r = resources
+      let r = resources;
 
       if (this.textSearch === "") {
         r = r;
@@ -313,11 +441,13 @@ export default defineComponent({
 
     groupWillBeEmpty(group) {
       if (
-        this.filteredResources(group[1].links, group[0]).length     === 0 &&
-        this.filteredResources(group[1].chats, group[0]).length     === 0 &&
+        this.filteredResources(group[1].links, group[0]).length === 0 &&
+        this.filteredResources(group[1].chats, group[0]).length === 0 &&
         this.filteredResources(group[1].publishes, group[0]).length === 0
-      ) { return true }
-      return false
+      ) {
+        return true;
+      }
+      return false;
     },
 
     chatsByGroup(groupName: string) {

--- a/interface/src/components/Known.vue
+++ b/interface/src/components/Known.vue
@@ -251,58 +251,64 @@ export default defineComponent({
     filteredResources(resources, groupName) {
       let r = resources
 
-      if (this.textSearch === '') {
-        r = r
+      if (this.textSearch === "") {
+        r = r;
       } else {
         r = r.filter((r) => {
-          const bits = r.name.split('-')
-          return bits.filter((s: string) => {
-            return s.toLowerCase().startsWith(this.textSearch.toLowerCase())
-          }).length > 0
-        })
+          // remove all heps and spaces from search term
+          const searchMashup = this.textSearch.replaceAll(/[-\s]/g, "");
+          // compare this to all groups/resources with same treatment
+          const resourceNameMashup = r.name.replaceAll(/[-\s]/g, "");
+          const groupNameMashup = groupName.replaceAll(/[-\s]/g, "");
+          return ( // join group and resource name search
+              groupNameMashup.toLowerCase().startsWith(searchMashup.toLowerCase()) ||
+              resourceNameMashup.toLowerCase().startsWith(searchMashup.toLowerCase()
+            )
+          );
+        });
       }
 
-      if (this.adminOnly === 'all') {
-        r = r
+      if (this.adminOnly === "all") {
+        r = r;
       }
-      if (this.adminOnly === 'admin') {
+      if (this.adminOnly === "admin") {
         r = r.filter((r) => {
           if (this.isAdmin(r, groupName)) {
-            return true
+            return true;
           }
-          return false
-        })
+          return false;
+        });
       }
-      if (this.adminOnly === 'not') {
+      if (this.adminOnly === "not") {
         r = r.filter((r) => {
           if (this.isAdmin(r, groupName)) {
-            return false
+            return false;
           }
-          return true
-        })
+          return true;
+        });
       }
 
-      if (this.showAllExportStatus === 'all') {
-        r = r
+      if (this.showAllExportStatus === "all") {
+        r = r;
       }
-      if (this.showAllExportStatus === 'auto') {
+      if (this.showAllExportStatus === "auto") {
         r = r.filter((r) => {
           if (this.isSaved(r)) {
-            return true
+            return true;
           }
-          return false
-        })
+          return false;
+        });
       }
-      if (this.showAllExportStatus === 'none') {
+      if (this.showAllExportStatus === "none") {
         r = r.filter((r) => {
           if (this.isSaved(r)) {
-            return false
+            return false;
           }
-          return true
-        })
+          return true;
+        });
       }
 
-      return r
+      return r;
     },
 
     groupWillBeEmpty(group) {

--- a/interface/src/components/Known.vue
+++ b/interface/src/components/Known.vue
@@ -121,13 +121,11 @@
             >
               <v-expansion-panel-title>
                 <div class="tw-w-full tw-flex tw-flex-row tw-justify-between">
-                  <div class="tw-text-xl">
+                  <div class="tw-flex-grow tw-text-left tw-text-xl">
                     {{ pair[0] }}
                   </div>
 
-                  <div class="tw-flex-grow"></div>
-
-                  <div>
+                  <div class="tw-flex-shrink tw-flex tw-flex-row tw-flex-wrap">
                     <v-tooltip location="top">
                       <template v-slot:activator="{ props }">
                         <v-chip

--- a/interface/src/components/Known.vue
+++ b/interface/src/components/Known.vue
@@ -100,6 +100,15 @@
     <div v-if="!knownPending">
       <!-- loaded -->
       <div>
+        <div class="tw-text-right tw-mb-2">
+          <span
+            href="#"
+            class="tw-cursor-pointer tw-text-success tw-underline"
+            @click="toggleExpandCollapseAll"
+          >
+            Expand/Collapse All
+          </span>
+        </div>
         <ul class="tw-my-4">
           <p
             v-if="filteredGroups.length === 0"
@@ -351,6 +360,14 @@ export default defineComponent({
         group[1].links.length +
         group[1].publishes.length
       );
+    },
+
+    toggleExpandCollapseAll() {
+      if (this.openPanels.length === 0) {
+        this.openPanels = this.filteredGroups.map(g => g[0])
+      } else {
+        this.openPanels = []
+      }
     },
 
     getKnown() {

--- a/interface/src/components/loading-skeletons/KnownSkeleton.vue
+++ b/interface/src/components/loading-skeletons/KnownSkeleton.vue
@@ -5,16 +5,13 @@
     <div class="tw-flex tw-animate-pulse">
       <div class="tw-flex-1 tw-py-1 tw-space-y-6">
         <div class="tw-space-y-3">
-          <div class="tw-grid tw-grid-cols-4 tw-gap-4">
-            <div class="tw-h-2 tw-rounded tw-bg-primary tw-col-span-1"></div>
+          <div class="tw-grid tw-grid-cols-9 tw-gap-1">
+            <div class="tw-h-2 tw-rounded tw-bg-primary tw-col-span-2"></div>
+            <div class="tw-h-2 tw-rounded tw-bg-white tw-col-span-4"></div>
             <div class="tw-h-2 tw-rounded tw-bg-info tw-col-span-1"></div>
-            <div class="tw-h-2 tw-rounded tw-bg-secondary tw-col-span-2"></div>
+            <div class="tw-h-2 tw-rounded tw-bg-info tw-col-span-1"></div>
+            <div class="tw-h-2 tw-rounded tw-bg-primary tw-col-span-1"></div>
           </div>
-          <div class="tw-h-2 tw-rounded tw-bg-secondary"></div>
-          <div class="tw-h-2 tw-rounded tw-bg-secondary"></div>
-        </div>
-        <div class="tw-grid tw-grid-cols-6">
-          <div class="tw-h-2 tw-rounded tw-bg-success tw-col-span-1"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Adds expansion panels for groups. Also extends text search to include group name (it was just resource names before) and fixes search to not get confused by heps.

starts off collapsed:

![image](https://user-images.githubusercontent.com/3201135/185212737-dffd4698-de99-4924-b2c4-5f2f637ce813.png)

![image](https://user-images.githubusercontent.com/3201135/185212759-60c4774b-ea2a-4c5a-8f64-df49f0cf77fe.png)

When searching or filtering, groups that match auto-expand:

![image](https://user-images.githubusercontent.com/3201135/185212955-745a2f02-c180-4a51-8453-9f1e65922f8f.png)
